### PR TITLE
fix: declare as an ESM

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,13 @@
-module.exports = {
-  preset: 'ts-jest',
-  moduleFileExtensions: ['ts', 'js'],
+export default {
+  transform: {},
+  preset: 'ts-jest/presets/default-esm',
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
 }

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "hacocms-js-sdk",
   "version": "0.1.0",
   "description": "hacoCMS SDK for JavaScript/TypeScript",
+  "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",
-    "test": "jest",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' npx jest",
     "lint": "npm run lint:eslint && npm run lint:prettier",
     "lint:eslint": "eslint src/**",
     "lint:prettier": "prettier --check .",

--- a/src/api-client.test.ts
+++ b/src/api-client.test.ts
@@ -1,7 +1,7 @@
 import http from 'http'
 import { AddressInfo } from 'net'
-import { HacoCmsClient } from './api-client'
-import { ApiContent } from './api-content'
+import { HacoCmsClient } from './api-client.js'
+import { ApiContent } from './api-content.js'
 
 class DummyApiContent extends ApiContent {}
 

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
-import { ApiContent } from './api-content'
-import { ConstructorFromJson, JsonType } from './json-utils'
-import { ListApiResponse, ListApiResponseInJson } from './api-response'
-import { QueryParameters } from './query'
+import { ApiContent } from './api-content.js'
+import { ConstructorFromJson, JsonType } from './json-utils.js'
+import { ListApiResponse, ListApiResponseInJson } from './api-response.js'
+import { QueryParameters } from './query.js'
 
 /**
  * hacoCMS の API クライアント

--- a/src/api-content.ts
+++ b/src/api-content.ts
@@ -1,4 +1,4 @@
-import { JsonType, toDate, toNullableDate } from './json-utils'
+import { JsonType, toDate, toNullableDate } from './json-utils.js'
 
 /**
  * コンテンツの基底クラス

--- a/src/api-response.ts
+++ b/src/api-response.ts
@@ -1,5 +1,5 @@
-import { ApiContent } from './api-content'
-import { ConstructorFromJson, JsonType } from './json-utils'
+import { ApiContent } from './api-content.js'
+import { ConstructorFromJson, JsonType } from './json-utils.js'
 
 type ApiMetaResponse = {
   total: number

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { HacoCmsClient } from './api-client'
-export { ApiContent } from './api-content'
-export { SortQuery } from './query'
-export { JsonType, toDate, toNullableDate } from './json-utils'
+export { HacoCmsClient } from './api-client.js'
+export { ApiContent } from './api-content.js'
+export { SortQuery } from './query.js'
+export { JsonType, toDate, toNullableDate } from './json-utils.js'

--- a/src/query.test.ts
+++ b/src/query.test.ts
@@ -1,4 +1,4 @@
-import { SortQuery } from './query'
+import { SortQuery } from './query.js'
 
 describe('build sort query', () => {
   test.each([


### PR DESCRIPTION
```js
export { HacoCmsClient } from './api-client'
```
のような ESM 形式を使う場合は package.json に `"type": "module"` が必要だった。
https://nodejs.org/docs/latest-v16.x/api/packages.html#packages_determining_module_system

CommonJS 扱いされて以下のようなエラーになってしまっていた。

```
export { HacoCmsClient } from './api-client';
^^^^^^

SyntaxError: Unexpected token 'export'
```

以下を参考に対応した。

- [Typescript\+ESMでnpmパッケージ開発した備忘録](https://zenn.dev/arark/articles/cc58ba9bb79d80ec9cd3#%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%AE%E5%88%9D%E6%9C%9F%E5%8C%96)
- [TypeScript \+ Jest で native ESM](https://zenn.dev/hankei6km/articles/native-esm-with-typescript-jest#%E3%83%87%E3%83%90%E3%83%83%E3%82%B0)
    - [ESM Support \| ts\-jest](https://kulshekhar.github.io/ts-jest/docs/guides/esm-support/#use-esm-presets)
    - [ECMAScript Modules · Jest](https://jestjs.io/ja/docs/ecmascript-modules)