### PR TITLE
fix: failed tests on Node 18

### DIFF
--- a/src/api-client.test.ts
+++ b/src/api-client.test.ts
@@ -238,13 +238,6 @@ async function makeStubServer(responses: readonly unknown[]) {
 }
 
 function getServerUrl(server: http.Server) {
-  const address = server.address()
-  if (address == null) {
-    throw new Error('server.address() returns null')
-  }
-  if (typeof address === 'string') {
-    return address
-  }
-  const { address: host, port } = address as AddressInfo
-  return `http://${host}:${port}`
+  const { address, port } = server.address() as AddressInfo
+  return `http://${address}:${port}`
 }

--- a/src/api-client.test.ts
+++ b/src/api-client.test.ts
@@ -238,6 +238,13 @@ async function makeStubServer(responses: readonly unknown[]) {
 }
 
 function getServerUrl(server: http.Server) {
-  const { address, port } = server.address() as AddressInfo
-  return `http://${address}:${port}`
+  const address = server.address()
+  if (address == null) {
+    throw new Error('server.address() returns null')
+  }
+  if (typeof address === 'string') {
+    return address
+  }
+  const { address: host, port } = address as AddressInfo
+  return `http://${host}:${port}`
 }

--- a/src/api-client.test.ts
+++ b/src/api-client.test.ts
@@ -212,7 +212,7 @@ describe('getContent', () => {
 
 async function createServer(listener: http.RequestListener) {
   const server = http.createServer(listener)
-  server.listen(undefined, 'localhost')
+  server.listen(undefined, '127.0.0.1')
   while (!server.address()) {
     await new Promise((resolve) => setTimeout(resolve, 10))
   }

--- a/src/api-client.test.ts
+++ b/src/api-client.test.ts
@@ -239,7 +239,6 @@ async function makeStubServer(responses: readonly unknown[]) {
 
 function getServerUrl(server: http.Server) {
   const address = server.address()
-  console.log(address)
   if (address == null) {
     throw new Error('server.address() returns null')
   }

--- a/src/api-client.test.ts
+++ b/src/api-client.test.ts
@@ -239,6 +239,7 @@ async function makeStubServer(responses: readonly unknown[]) {
 
 function getServerUrl(server: http.Server) {
   const address = server.address()
+  console.log(address)
   if (address == null) {
     throw new Error('server.address() returns null')
   }


### PR DESCRIPTION
Node 18 でだけテストに失敗していた件。
`server.address()` でアドレスが IPv6 で返ってきていた。
```
    console.log
      { address: '::1', family: 'IPv6', port: 45471 }

      at getServerUrl (src/api-client.test.ts:242:11)
```

`http://::1/api/v1/...` となってこれはパースできないらしい。