### PR TITLE
fix: modulesのdefaultは最後に書く

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,16 +9,16 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/esm/index.js",
-        "types": "./dist/esm/index.d.ts"
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.cjs",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.cjs"
       },
       "node": {
-        "default": "./dist/cjs/index.cjs",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.cjs"
       }
     }
   },


### PR DESCRIPTION
https://nodejs.org/docs/latest-v18.x/api/packages.html#conditional-exports

> - "default" - the generic fallback that always matches. Can be a CommonJS or ES module file. This condition should always come last.
