### PR TITLE
chore(tsc): set `module` option to `NodeNext`

### DIFF
--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ESNext", "ESNext.AsyncIterable", "DOM"],
     "outDir": "dist/esm"


### PR DESCRIPTION
fix https://github.com/hacocms/hacocms-js-sdk/actions/runs/5971062299/job/16199566236?pr=180#step:5:13